### PR TITLE
Adds items endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,13 +28,13 @@ gem 'active_model_serializers', '~> 0.10.0'
 # gem 'rack-cors'
 gem 'rspec-rails'
 
-gem 'factory_girl_rails'
+# gem 'factory_girl_rails'
 gem 'pry'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
-  #gem 'factory_girl_rails',"~> 4.0", :require => false
+  gem 'factory_girl_rails',"~> 4.0", :require => false
 end
 gem 'simplecov', :require => false, :group => :test
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   byebug
-  factory_girl_rails
+  factory_girl_rails (~> 4.0)
   faker
   listen (~> 3.0.5)
   pg (~> 0.18)

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,33 @@
+class Api::V1::ItemsController < ApplicationController
+
+  def index
+    render json: Item.all
+  end
+
+  def show
+    render json: Item.find(params[:id])
+  end
+
+  def find
+    render json: Item.search(search_params)
+  end
+
+  def random
+    render json: Item.find_random
+  end
+
+  def find_all
+    render json: Item.search_all(search_params)
+  end
+
+private
+  def search_params
+    params.permit(:id,
+                  :name,
+                  :description,
+                  :unit_price,
+                  :merchant_id,
+                  :created_at,
+                  :updated_at)
+  end
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,4 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id, :description, :name, :merchant_id, :unit_price
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,11 @@ Rails.application.routes.draw do
       #customers
       get "/customers/find" => "customers#find"
       resources :customers, only: [:index, :show]
+
+      get "/items/find" => "items#find"
+      get "/items/find_all" => "items#find_all"
+      get "items/random" => "items#random"
+      resources :items, only: [:index, :show]
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,3 +20,9 @@ STATUS = ["Ordered", "Shipped", "Paid", "Cancelled"]
                    merchant_id: Faker::Number.between(1, 4843),
                    status: STATUS.sample)
   end
+  2483.times do
+    Item.create(name: Faker::Name.first_name,
+                description: Faker::Name.first_name,
+                unit_price: Faker::Number.between(1, 20),
+                merchant_id: Faker::Number.between(1, 4843))
+  end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :item do
-    name "ItemName"
-    description "ItemDescription"
+    name "Hammer"
+    description "Heavy shiny"
     unit_price 1.5
-    merchant Merchant.create()
+    merchant_id Merchant.create().id
   end
 end

--- a/spec/requests/api/v1/item_request_spec.rb
+++ b/spec/requests/api/v1/item_request_spec.rb
@@ -1,0 +1,204 @@
+require 'rails_helper'
+
+describe "Invoices API" do
+  it "sends a list of items" do
+    create_list(:item, 3)
+
+    get '/api/v1/items.json'
+
+    expect(response).to be_success
+
+    items = JSON.parse(response.body)
+    
+    expect(items.count).to eq(3)
+  end
+
+  it "sends a single item" do
+    id = create(:item).id
+
+    get "/api/v1/items/#{id}"
+
+    expect(response).to be_success
+
+    item_json = JSON.parse(response.body)
+
+    expect(item_json["id"]).to eq(id)
+    expect(item_json["name"]).to eq(Item.find(id).name)
+    expect(item_json["merchant_id"]).to eq(Item.find(id).merchant_id)
+    expect(item_json["description"]).to eq(Item.find(id).description)
+    expect(item_json["unit_price"]).to eq(Item.find(id).unit_price)
+  end
+
+    it "returns an item based on merchant_id" do
+      item = create(:item)
+
+      get "/api/v1/items/find?merchant_id=#{item.merchant_id}"
+
+      expect(response).to be_success
+
+      item_json = JSON.parse(response.body)
+
+      expect(item_json["merchant_id"]).to eq(item.merchant_id)
+    end
+
+    it "returns an item based on name" do
+      item = create(:item)
+
+      get "/api/v1/items/find?name=#{item.name}"
+
+      expect(response).to be_success
+
+      item_json = JSON.parse(response.body)
+
+      expect(item_json["name"]).to eq(item.name)
+    end
+
+    it "returns an item based on description" do
+      item = create(:item)
+
+      get "/api/v1/items/find?description=#{item.description}"
+
+      expect(response).to be_success
+
+      item_json = JSON.parse(response.body)
+
+      expect(item_json["description"]).to eq(item.description)
+    end
+
+    it "returns an item based on created at stamp" do
+      item = create(:item,
+                    created_at: "2012-03-27 14:54:09 UTC")
+
+      get "/api/v1/items/find?created_at=#{item.created_at}"
+
+      expect(response).to be_success
+
+      item_json = JSON.parse(response.body)
+
+      expect(item_json["id"]).to eq(item.id)
+    end
+
+    it "returns an item based on updated at stamp" do
+      item = create(:item,
+                    updated_at: "2012-03-27 14:54:09 UTC")
+
+      get "/api/v1/items/find?updated_at=#{item.updated_at}"
+
+      expect(response).to be_success
+
+      item_json = JSON.parse(response.body)
+
+      expect(item_json["id"]).to eq(item.id)
+    end
+
+    it "returns a random item" do
+      create(:item)
+      create(:item)
+
+
+      get "/api/v1/items/random"
+
+      expect(response).to be_success
+
+      item_json = JSON.parse(response.body)[0]
+      id = item_json["id"]
+      expect(item_json["merchant_id"]).to eq(Item.find(id)[:merchant_id])
+      expect(item_json["name"]).to eq(Item.find(id)[:name])
+      expect(item_json["description"]).to eq(Item.find(id)[:description])
+      expect(item_json["unit_price"]).to eq(Item.find(id)[:unit_price])
+    end
+
+    it "returns all items found by merchant_id" do
+      create(:item,
+              merchant_id: 1)
+      create(:item,
+              merchant_id: 1)
+
+      get "/api/v1/items/find_all?merchant_id=1"
+
+      expect(response).to be_success
+
+      json_response = JSON.parse(response.body)
+      expect(json_response[0]["merchant_id"]).to eq(1)
+      expect(json_response[1]["merchant_id"]).to eq(1)
+      expect(json_response.count).to eq(2)
+    end
+
+    it "returns all items found by name" do
+      create(:item)
+      create(:item)
+
+      get "/api/v1/items/find_all?name=Hammer"
+
+      expect(response).to be_success
+
+      json_response = JSON.parse(response.body)
+      expect(json_response[0]["name"]).to eq("Hammer")
+      expect(json_response[1]["name"]).to eq("Hammer")
+      expect(json_response.count).to eq(2)
+    end
+
+    it "returns all items found by description" do
+      create(:item,
+              description: 'Shiny')
+      create(:item,
+              description: 'Shiny')
+
+      get "/api/v1/items/find_all?description=Shiny"
+
+      expect(response).to be_success
+
+      json_response = JSON.parse(response.body)
+      expect(json_response[0]["description"]).to eq('Shiny')
+      expect(json_response[1]["description"]).to eq('Shiny')
+      expect(json_response.count).to eq(2)
+    end
+
+    it "returns all items found by created_at" do
+      create(:item,
+            created_at: "2012-03-27 14:54:09 UTC")
+      create(:item,
+            created_at: "2012-03-27 14:54:09 UTC")
+
+
+      get "/api/v1/items/find_all?created_at=2012-03-27 14:54:09 UTC"
+
+      expect(response).to be_success
+
+      json_response = JSON.parse(response.body)
+      expect(json_response[0]["name"]).to eq('Hammer')
+      expect(json_response[1]["name"]).to eq('Hammer')
+      expect(json_response.count).to eq(2)
+    end
+
+    it "returns all items found by updated at" do
+      create(:item,
+            updated_at: "2012-03-27 14:54:09 UTC")
+      create(:item,
+            updated_at: "2012-03-27 14:54:09 UTC")
+
+
+      get "/api/v1/items/find_all?updated_at=2012-03-27 14:54:09 UTC"
+
+      expect(response).to be_success
+
+      json_response = JSON.parse(response.body)
+      expect(json_response[0]["name"]).to eq('Hammer')
+      expect(json_response[1]["name"]).to eq('Hammer')
+      expect(json_response.count).to eq(2)
+    end
+
+    it "returns all items found by id" do
+      id = create(:item).id
+      create(:item)
+
+      get "/api/v1/items/find_all?id=#{id}"
+
+      expect(response).to be_success
+
+      json_response = JSON.parse(response.body)
+      expect(json_response[0]["name"]).to eq('Hammer')
+      expect(json_response[0]["id"]).to eq(id)
+      expect(json_response.count).to eq(1)
+    end
+end


### PR DESCRIPTION
Builds out all endpoints for items
as described by spec. All local
tests are currently passing.
Serializer generated for item
which excludes return of timestamps
as per spec. Spec harness is being
slightly wonky still. Given the errors
I think tackling the import of the data
next would be a great idea, so we won't be
aiming in the dark.