### PR TITLE
Adds merchant relationship endpoints

### DIFF
--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -19,6 +19,14 @@ class Api::V1::MerchantsController < ApplicationController
     render json: Merchant.find_random
   end
 
+  def merchant_items
+    render json: Merchant.items(params)
+  end
+
+  def merchant_invoices
+    render json: Merchant.invoices(params)
+  end
+
   private
 
   def search_params

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,4 +2,11 @@ class Merchant < ApplicationRecord
   has_many :items
   has_many :invoices
 
+  def self.items(params)
+    find(params[:id]).items
+  end
+
+  def self.invoices(params)
+    find(params[:id]).invoices
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
       get "/merchants/find" => "merchants#find"
       get "/merchants/find_all" => "merchants#find_all"
       get "/merchants/random" => "merchants#random"
-      resources :merchants, only: [:index, :show]
+      get "/merchants" => "merchants#index"
+      get "/merchants/:id(.:format)" => "merchants#show"
+      get "/merchants/:id/items(.:format)" => "merchants#merchant_items"
+      get "/merchants/:id/invoices(.:format)" => "merchants#merchant_invoices"
 
       #invoices
       get '/invoices/find' => "invoices#find"

--- a/spec/requests/api/v1/merchant_relationships_spec.rb
+++ b/spec/requests/api/v1/merchant_relationships_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe 'Merchant API relationship endpoints' do
+  it 'returns collection of items associated with a merchant' do
+    merchant = create(:merchant)
+    merchant.items.create(name: 'test1')
+    merchant.items.create(name: 'test2')
+    merchant.items.create(name: 'test3')
+
+    get "/api/v1/merchants/#{merchant.id}/items"
+
+    expect(response).to be_success
+
+    merchant_items = JSON.parse(response.body)
+
+    expect(merchant_items[0]["name"]).to eq('test1')
+    expect(merchant_items[1]["name"]).to eq('test2')
+    expect(merchant_items[2]["name"]).to eq('test3')
+
+  end
+
+  it 'returns collection of invoices associated with a merchant' do
+    merchant = create(:merchant)
+    customer = create(:customer)
+    merchant.invoices.create(status: 'test1', customer_id: customer.id)
+    merchant.invoices.create(status: 'test2', customer_id: customer.id)
+    merchant.invoices.create(status: 'test3', customer_id: customer.id)
+
+    get "/api/v1/merchants/#{merchant.id}/invoices"
+
+    expect(response).to be_success
+
+    merchant_invoices = JSON.parse(response.body)
+
+    expect(merchant_invoices[0]["status"]).to eq('test1')
+    expect(merchant_invoices[1]["status"]).to eq('test2')
+    expect(merchant_invoices[2]["status"]).to eq('test3')
+  end
+end


### PR DESCRIPTION
Adds test file for merchant_relationships
endpoints. Adds necessary methods to model.
Modifies routes file to include routes to
merchant controller for relationship queries.
All RSpec tests currently passing. Test harness
is passing appropriately for person B assignments.

Apologies for the branch this is was pushed in on.
It was a mistake last night.